### PR TITLE
Delegate adding solution to a group using a proxy

### DIFF
--- a/docs/delegate_solution_onboarding.md
+++ b/docs/delegate_solution_onboarding.md
@@ -22,7 +22,7 @@ const main = async () => {
   // 2 - Create a transaction to call a function using the proxy
   const solutionAdditionTx = api.tx.workerNodePallet.addSolutionToGroup(groupNamespace, solutionNamespace);
 
-  // 2 - Use the delegatee to add solution to group 
+  // 2 - Use the delegate to add solution to group 
   // Create a proxy transaction to call the function on behalf of the stash account
   const proxyCallTx = api.tx.proxy.proxy(stashAccount.address, proxyType, solutionAdditionTx);
 

--- a/docs/delegate_solution_onboarding.md
+++ b/docs/delegate_solution_onboarding.md
@@ -1,0 +1,73 @@
+```ts
+import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
+
+const main = async () => {
+  const provider = new WsProvider('wss://your-substrate-node-endpoint');
+  const api = await ApiPromise.create({ provider });
+
+  const keyring = new Keyring({ type: 'sr25519' });
+
+  const stashAccount = keyring.addFromUri('//Alice'); // Replace with the actual stash account
+  const proxyAccount = keyring.addFromUri('//Bob'); // Replace with the actual proxy account
+
+  // 1 - adding a new delegate
+  await delegateSolitionAddition(stashAccount, proxyAccount, api);
+
+  /* 
+    Before adding a solution to a group
+    Register solution group and solution: 
+    refer to the associated docs
+  */
+  // 2 - Create a transaction to call a function using the proxy
+  const solutionAdditionTx = api.tx.workerNodePallet.addSolutionToGroup(groupNamespace, solutionNamespace);
+
+  // 2 - Use the delegatee to add solution to group 
+  // Create a proxy transaction to call the function on behalf of the stash account
+  const proxyCallTx = api.tx.proxy.proxy(stashAccount.address, 'SolutionRegistrar', solutionAdditionTx);
+
+  // Sign and send the proxy call transaction using the proxy account
+  await proxyCallTx.signAndSend(proxyAccount, (result) => {
+    const {status, isError} = result;
+    
+    console.log(`Proxy Call - Current status is ${result.status}`);
+
+    if (status.isFinalized) {
+      console.log(`Proxy Call - Transaction finalized at blockHash ${result.status.asFinalized}`);
+    } else if (isError) {
+      console.error(`Proxy Call - Transaction error: ${result.toHuman()}`);
+    }
+  }).catch((error) => {
+    console.error(`Proxy Call - Failed to send transaction: ${error}`);
+  });
+};
+
+
+const delegateSolitionAddition = async (delegator, delegee, api) => {
+  // Define the custom proxy type
+  // Use createType to ensure the custom proxy type is correctly instantiated
+  const solutionAdditionProxyType = api.createType('ProxyType', 'SolutionRegistrar');
+
+  // Define the delay in number of blocks (0 if no delay is needed)
+  const delay = 0;
+
+  // Create the transaction to add the proxy
+  const tx = api.tx.proxy.addProxy(delegator.address, solutionAdditionProxyType, delay);
+
+  // Sign and send the transaction using the stash account
+  const unsub = await tx.signAndSend(stashAccount, (result) => {
+    console.log(`Current status is ${result.status}`);
+
+    if (result.status.isInBlock) {
+      console.log(`Transaction included at blockHash ${result.status.asInBlock}`);
+    } else if (result.status.isFinalized) {
+      console.log(`Transaction finalized at blockHash ${result.status.asFinalized}`);
+      unsub();
+    }
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});
+```

--- a/docs/delegate_solution_onboarding.md
+++ b/docs/delegate_solution_onboarding.md
@@ -1,5 +1,6 @@
 ```ts
 import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
+const proxyType = 'SolutionToGroupAdder';
 
 const main = async () => {
   const provider = new WsProvider('wss://your-substrate-node-endpoint');
@@ -23,7 +24,7 @@ const main = async () => {
 
   // 2 - Use the delegatee to add solution to group 
   // Create a proxy transaction to call the function on behalf of the stash account
-  const proxyCallTx = api.tx.proxy.proxy(stashAccount.address, 'SolutionRegistrar', solutionAdditionTx);
+  const proxyCallTx = api.tx.proxy.proxy(stashAccount.address, proxyType, solutionAdditionTx);
 
   // Sign and send the proxy call transaction using the proxy account
   await proxyCallTx.signAndSend(proxyAccount, (result) => {
@@ -42,19 +43,16 @@ const main = async () => {
 };
 
 
-const delegateSolitionAddition = async (delegator, delegee, api) => {
-  // Define the custom proxy type
-  // Use createType to ensure the custom proxy type is correctly instantiated
-  const solutionAdditionProxyType = api.createType('ProxyType', 'SolutionRegistrar');
+const delegateSolitionAddition = async (delegator, delegate, api) => {
 
   // Define the delay in number of blocks (0 if no delay is needed)
   const delay = 0;
 
   // Create the transaction to add the proxy
-  const tx = api.tx.proxy.addProxy(delegator.address, solutionAdditionProxyType, delay);
+  const tx = api.tx.proxy.addProxy(delegate.address, proxyType, delay);
 
   // Sign and send the transaction using the stash account
-  const unsub = await tx.signAndSend(stashAccount, (result) => {
+  const unsub = await tx.signAndSend(delegator, (result) => {
     console.log(`Current status is ${result.status}`);
 
     if (result.status.isInBlock) {


### PR DESCRIPTION
This PR adds a documentation exemple to allow a solution group owner to delegate the possibility to add solutions to an owned group to one or multiple other accounts (proxies). 

- [x] Documentation updated