### PR TITLE
feat/ewx-641: add withdrawal delay on solution group registration

### DIFF
--- a/docs/register_solution_group.md
+++ b/docs/register_solution_group.md
@@ -38,6 +38,7 @@ async function main(): Promise<void> {
   const withdrawal_delay = 5
 
   // Registering of solution group reserves part of the free balance. The amount of the reserved funds can be queried as `registrarDeposit()`
+   // @dev : the withdrawal delay is the number of blocks to wait before withdrawal request is executed
   await new Promise<void>(async (resolve) => {
     let unsub = await api.tx.workerNodePallet
       .solutionGroupRegistration(

--- a/docs/register_solution_group.md
+++ b/docs/register_solution_group.md
@@ -35,6 +35,7 @@ async function main(): Promise<void> {
   }
   const operation_start_block = 10
   const operation_end_block = 1000
+  const withdrawal_delay = 5
 
   // Registering of solution group reserves part of the free balance. The amount of the reserved funds can be queried as `registrarDeposit()`
   await new Promise<void>(async (resolve) => {
@@ -45,7 +46,8 @@ async function main(): Promise<void> {
         solution_group_operators_config,
         solution_group_reward_config,
         operation_start_block,
-        operation_end_block
+        operation_end_block,
+        withdrawal_delay
       )
       .signAndSend(REGISTRAR_KEYRING, ({ events }) => {
         if (events.some(({ event: { method, section } }) => "ExtrinsicSuccess" === method && section == "system")) {


### PR DESCRIPTION
This pr updates the documentation of solution group registration by adding a `withdrawal_delay` on the extrinsic call.
